### PR TITLE
Changed names for compatibility with newer relic version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The implementation uses the [relic toolkit](https://github.com/relic-toolkit/rel
 ### Install Relic
 The default settings to install relic.
 ```
-./preset/gmp-pbc-128.sh
+./preset/gmp-pbc-bls381.sh
 make 
 sudo make install
 ```

--- a/pre/encoding.c
+++ b/pre/encoding.c
@@ -74,7 +74,7 @@ int encode_params(char *buff, int size, pre_params_t params) {
 
   next_size = gt_size_bin(params->Z, COMPRESS_KEYS);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (u_int16_t)next_size);
   curr += ENCODING_SIZE;
@@ -83,7 +83,7 @@ int encode_params(char *buff, int size, pre_params_t params) {
 
   next_size = g1_size_bin(params->g1, COMPRESS_KEYS);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (u_int16_t)next_size);
   curr += ENCODING_SIZE;
@@ -92,7 +92,7 @@ int encode_params(char *buff, int size, pre_params_t params) {
 
   next_size = g2_size_bin(params->g2, COMPRESS_KEYS);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (u_int16_t)next_size);
   curr += ENCODING_SIZE;
@@ -101,20 +101,20 @@ int encode_params(char *buff, int size, pre_params_t params) {
 
   next_size = bn_size_bin(params->g1_ord);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, next_size);
   curr += ENCODING_SIZE;
   bn_write_bin((uint8_t *)curr, next_size, params->g1_ord);
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_params(pre_params_t params, char *buff, int size) {
   int next_size, dyn_size = 0;
   char *curr = buff;
   if (size < 4) {
-    return STS_ERR;
+    return RLC_ERR;
   }
 
   g1_new(params->g1);
@@ -124,11 +124,11 @@ int decode_params(pre_params_t params, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   gt_read_bin(params->Z, (uint8_t *)curr, next_size);
@@ -136,11 +136,11 @@ int decode_params(pre_params_t params, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   g1_read_bin(params->g1, (uint8_t *)curr, next_size);
@@ -148,11 +148,11 @@ int decode_params(pre_params_t params, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   g2_read_bin(params->g2, (uint8_t *)curr, next_size);
@@ -160,17 +160,17 @@ int decode_params(pre_params_t params, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   bn_read_bin(params->g1_ord, (uint8_t *)curr, next_size);
   curr += next_size;
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int get_encoded_sk_size(pre_sk_t sk) {
@@ -186,7 +186,7 @@ int encode_sk(char *buff, int size, pre_sk_t sk) {
 
   next_size = bn_size_bin(sk->a);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, next_size);
   curr += ENCODING_SIZE;
@@ -195,20 +195,20 @@ int encode_sk(char *buff, int size, pre_sk_t sk) {
 
   next_size = bn_size_bin(sk->a_inv);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, next_size);
   curr += ENCODING_SIZE;
   bn_write_bin((uint8_t *)curr, next_size, sk->a_inv);
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_sk(pre_sk_t sk, char *buff, int size) {
   int next_size, dyn_size = 0;
   char *curr = buff;
   if (size < 4) {
-    return STS_ERR;
+    return RLC_ERR;
   }
 
   bn_new(sk->a);
@@ -216,11 +216,11 @@ int decode_sk(pre_sk_t sk, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   bn_read_bin(sk->a, (uint8_t *)curr, next_size);
@@ -228,17 +228,17 @@ int decode_sk(pre_sk_t sk, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   bn_read_bin(sk->a_inv, (uint8_t *)curr, next_size);
   curr += next_size;
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int get_encoded_pk_size(pre_pk_t pk) {
@@ -254,7 +254,7 @@ int encode_pk(char *buff, int size, pre_pk_t pk) {
 
   next_size = g1_size_bin(pk->pk1, COMPRESS_KEYS);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (u_int16_t)next_size);
   curr += ENCODING_SIZE;
@@ -263,21 +263,21 @@ int encode_pk(char *buff, int size, pre_pk_t pk) {
 
   next_size = g2_size_bin(pk->pk2, COMPRESS_KEYS);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (u_int16_t)next_size);
   curr += ENCODING_SIZE;
   g2_write_bin((uint8_t *)curr, next_size, pk->pk2, COMPRESS_KEYS);
   curr += next_size;
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_pk(pre_pk_t pk, char *buff, int size) {
   int next_size, dyn_size = 0;
   char *curr = buff;
   if (size < 4) {
-    return STS_ERR;
+    return RLC_ERR;
   }
 
   g1_new(pk->pk1);
@@ -285,11 +285,11 @@ int decode_pk(pre_pk_t pk, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   g1_read_bin(pk->pk1, (uint8_t *)curr, next_size);
@@ -297,17 +297,17 @@ int decode_pk(pre_pk_t pk, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   g2_read_bin(pk->pk2, (uint8_t *)curr, next_size);
   curr += next_size;
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int get_encoded_token_size(pre_token_t token) {
@@ -317,16 +317,16 @@ int get_encoded_token_size(pre_token_t token) {
 int encode_token(char *buff, int size, pre_token_t token) {
   int next_size = g2_size_bin(token->token, COMPRESS_KEYS);
   if (size < next_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   g2_write_bin((uint8_t *)buff, next_size, token->token, COMPRESS_KEYS);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_token(pre_token_t token, char *buff, int size) {
   g2_new(token->token);
   g2_read_bin(token->token, (uint8_t *)buff, size);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int get_encoded_plaintext_size(pre_plaintext_t plaintext) {
@@ -336,16 +336,16 @@ int get_encoded_plaintext_size(pre_plaintext_t plaintext) {
 int encode_plaintext(char *buff, int size, pre_plaintext_t plaintext) {
   int next_size = gt_size_bin(plaintext->msg, COMPRESS_DATA);
   if (size < next_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   gt_write_bin((uint8_t *)buff, next_size, plaintext->msg, COMPRESS_DATA);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_plaintext(pre_plaintext_t plaintext, char *buff, int size) {
   gt_new(plaintext->msg);
   gt_read_bin(plaintext->msg, (uint8_t *)buff, size);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int get_encoded_ciphertext_size(pre_ciphertext_t ciphertext) {
@@ -361,7 +361,7 @@ int encode_ciphertext(char *buff, int size, pre_ciphertext_t ciphertext) {
 
   next_size = gt_size_bin(ciphertext->c1, COMPRESS_DATA);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (uint16_t)next_size);
   curr += ENCODING_SIZE;
@@ -370,20 +370,20 @@ int encode_ciphertext(char *buff, int size, pre_ciphertext_t ciphertext) {
 
   next_size = g1_size_bin(ciphertext->c2, COMPRESS_DATA);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (uint16_t)next_size);
   curr += ENCODING_SIZE;
   g1_write_bin((uint8_t *)curr, next_size, ciphertext->c2, COMPRESS_DATA);
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_ciphertext(pre_ciphertext_t ciphertext, char *buff, int size) {
   int next_size, dyn_size = 0;
   char *curr = buff;
   if (size < 4) {
-    return STS_ERR;
+    return RLC_ERR;
   }
 
   gt_new(ciphertext->c1);
@@ -391,11 +391,11 @@ int decode_ciphertext(pre_ciphertext_t ciphertext, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   gt_read_bin(ciphertext->c1, (uint8_t *)curr, next_size);
@@ -403,16 +403,16 @@ int decode_ciphertext(pre_ciphertext_t ciphertext, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   g1_read_bin(ciphertext->c2, (uint8_t *)curr, next_size);
 
-  return STS_OK;
+  return RLC_OK;
 }
 
 int get_encoded_re_ciphertext_size(pre_re_ciphertext_t ciphertext) {
@@ -428,7 +428,7 @@ int encode_re_ciphertext(char *buff, int size, pre_re_ciphertext_t ciphertext) {
 
   next_size = gt_size_bin(ciphertext->c1, COMPRESS_DATA);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (uint16_t)next_size);
   curr += ENCODING_SIZE;
@@ -437,19 +437,19 @@ int encode_re_ciphertext(char *buff, int size, pre_re_ciphertext_t ciphertext) {
 
   next_size = gt_size_bin(ciphertext->c2, COMPRESS_DATA);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   write_size(curr, (u_int16_t)next_size);
   curr += ENCODING_SIZE;
   gt_write_bin((uint8_t *)curr, next_size, ciphertext->c2, COMPRESS_DATA);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int decode_re_ciphertext(pre_re_ciphertext_t ciphertext, char *buff, int size) {
   int next_size, dyn_size = 0;
   char *curr = buff;
   if (size < 4) {
-    return STS_ERR;
+    return RLC_ERR;
   }
 
   gt_new(ciphertext->c1);
@@ -457,11 +457,11 @@ int decode_re_ciphertext(pre_re_ciphertext_t ciphertext, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   gt_read_bin(ciphertext->c1, (uint8_t *)curr, next_size);
@@ -469,14 +469,14 @@ int decode_re_ciphertext(pre_re_ciphertext_t ciphertext, char *buff, int size) {
 
   next_size = read_size(curr);
   if (!valid_bounds(buff, curr, next_size, size)) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   dyn_size += next_size + ENCODING_SIZE;
   if (size < dyn_size) {
-    return STS_ERR;
+    return RLC_ERR;
   }
   curr += ENCODING_SIZE;
   gt_read_bin(ciphertext->c2, (uint8_t *)curr, next_size);
 
-  return STS_OK;
+  return RLC_OK;
 }

--- a/pre/encryption.c
+++ b/pre/encryption.c
@@ -39,7 +39,7 @@
 
 int pre_encrypt(pre_ciphertext_t ciphertext, pre_params_t params,
 		pre_pk_t pk, pre_plaintext_t plaintext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   bn_t r;
 
@@ -79,7 +79,7 @@ int pre_encrypt(pre_ciphertext_t ciphertext, pre_params_t params,
     g1_mul(ciphertext->c2, pk->pk1, r);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
     gt_null(ciphertext->c1);
     g1_null(ciphertext->c2);
   }
@@ -92,7 +92,7 @@ int pre_encrypt(pre_ciphertext_t ciphertext, pre_params_t params,
 
 int pre_decrypt(pre_plaintext_t plaintext, pre_params_t params,
 		pre_sk_t sk, pre_ciphertext_t ciphertext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   g2_t t1;
   gt_t t0;
@@ -126,7 +126,7 @@ int pre_decrypt(pre_plaintext_t plaintext, pre_params_t params,
     gt_inv(t0, plaintext->msg);
     gt_mul(plaintext->msg, ciphertext->c1, t0);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
   FINALLY {
     gt_free(t0);
     g1_free(t1);
@@ -137,7 +137,7 @@ int pre_decrypt(pre_plaintext_t plaintext, pre_params_t params,
 
 int pre_decrypt_re(pre_plaintext_t plaintext, pre_params_t params,
 		pre_sk_t sk, pre_re_ciphertext_t ciphertext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   gt_t t0;
 
@@ -169,7 +169,7 @@ int pre_decrypt_re(pre_plaintext_t plaintext, pre_params_t params,
     gt_inv(t0, plaintext->msg);
     gt_mul(plaintext->msg, ciphertext->c1, t0);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
   FINALLY {
     gt_free(t0);
   }
@@ -179,7 +179,7 @@ int pre_decrypt_re(pre_plaintext_t plaintext, pre_params_t params,
 
 int pre_apply_token(pre_re_ciphertext_t re_ciphertext, pre_token_t token, 
                  pre_ciphertext_t ciphertext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     assert(token);
@@ -197,7 +197,7 @@ int pre_apply_token(pre_re_ciphertext_t re_ciphertext, pre_token_t token,
     pc_map(re_ciphertext->c2, ciphertext->c2, token->token);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
     gt_null(re_ciphertext->c1);
     gt_null(re_ciphertext->c2);
   }

--- a/pre/keygen.c
+++ b/pre/keygen.c
@@ -40,7 +40,7 @@
 // Helper function to compute 1/a mod m
 int mod_inverse(bn_t res, bn_t a, bn_t m) {
   bn_t tempGcd, temp;
-  int result = STS_OK;
+  int result = RLC_OK;
 
   bn_null(tempGcd);
   bn_null(temp);
@@ -51,11 +51,11 @@ int mod_inverse(bn_t res, bn_t a, bn_t m) {
     bn_new(temp);
 
     bn_gcd_ext(tempGcd, res, temp, a, m);
-    if (bn_sign(res) == BN_NEG) {
+    if (bn_sign(res) == RLC_NEG) {
       bn_add(res, res, m);
     }
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
   FINALLY {
     bn_free(tempGcd);
     bn_free(temp);
@@ -65,7 +65,7 @@ int mod_inverse(bn_t res, bn_t a, bn_t m) {
 }
 
 int pre_generate_params(pre_params_t params) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   g1_null(params->g1);
   g2_null(params->g2);
@@ -87,7 +87,7 @@ int pre_generate_params(pre_params_t params) {
     g1_get_ord(params->g1_ord);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
 
     g1_null(params->g1);
     g2_null(params->g2);
@@ -99,7 +99,7 @@ int pre_generate_params(pre_params_t params) {
 }
 
 int pre_generate_sk(pre_sk_t sk, pre_params_t params) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   bn_null(sk->a);
   bn_null(sk->a_inv);
@@ -115,7 +115,7 @@ int pre_generate_sk(pre_sk_t sk, pre_params_t params) {
     mod_inverse(sk->a_inv, sk->a, params->g1_ord);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
 
     bn_null(sk->a);
     bn_null(sk->a_inv);
@@ -125,7 +125,7 @@ int pre_generate_sk(pre_sk_t sk, pre_params_t params) {
 }
 
 int pre_derive_pk(pre_pk_t pk, pre_params_t params, pre_sk_t sk) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   g1_null(pk->pk1);
   g2_null(pk->pk2);
@@ -139,7 +139,7 @@ int pre_derive_pk(pre_pk_t pk, pre_params_t params, pre_sk_t sk) {
     g2_mul_gen(pk->pk2, sk->a);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
 
     g1_null(pk->pk1);
     g2_null(pk->pk2);
@@ -150,7 +150,7 @@ int pre_derive_pk(pre_pk_t pk, pre_params_t params, pre_sk_t sk) {
 
 // Helper function to compute the hash of a public key (used for key derivation)
 int hash_pk(bn_t hash, g1_t g1_hash, g2_t g2_hash, pre_pk_t pk) { 
-  int result = STS_ERR;
+  int result = RLC_ERR;
 
   int size;
 
@@ -174,7 +174,7 @@ int hash_pk(bn_t hash, g1_t g1_hash, g2_t g2_hash, pre_pk_t pk) {
     g2_mul_gen(g2_hash, hash);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
 
     bn_null(hash_int);
     g1_null(g1_hash);
@@ -188,7 +188,7 @@ int hash_pk(bn_t hash, g1_t g1_hash, g2_t g2_hash, pre_pk_t pk) {
 }
 
 int pre_derive_next_pk(pre_pk_t new_pk, pre_pk_t old_pk) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   bn_t hash;
   g1_t g1_hash;
@@ -209,7 +209,7 @@ int pre_derive_next_pk(pre_pk_t new_pk, pre_pk_t old_pk) {
     g2_add(new_pk->pk2, old_pk->pk2, g2_hash);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
 
     bn_free(hash);
     g1_free(g1_hash);
@@ -228,7 +228,7 @@ int pre_derive_next_pk(pre_pk_t new_pk, pre_pk_t old_pk) {
 
 int pre_derive_next_keypair(pre_sk_t new_sk, pre_pk_t new_pk, 
 		pre_params_t params, pre_sk_t old_sk, pre_pk_t old_pk) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   bn_t hash;
   g1_t g1_hash;
@@ -257,7 +257,7 @@ int pre_derive_next_keypair(pre_sk_t new_sk, pre_pk_t new_pk,
     mod_inverse(new_sk->a_inv, new_sk->a, params->g1_ord);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
 
     bn_free(hash);
     g1_free(g1_hash);
@@ -278,7 +278,7 @@ int pre_derive_next_keypair(pre_sk_t new_sk, pre_pk_t new_pk,
 
 int pre_generate_token(pre_token_t token, pre_params_t params,
 		pre_sk_t sk, pre_pk_t pk) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   g2_null(token->token);
   TRY {
@@ -293,7 +293,7 @@ int pre_generate_token(pre_token_t token, pre_params_t params,
     g2_mul(token->token, pk->pk2, sk->a_inv);
   }
   CATCH_ANY {
-    result = STS_ERR;
+    result = RLC_ERR;
     g2_null(token->token);
   };
 

--- a/pre/test.cpp
+++ b/pre/test.cpp
@@ -67,7 +67,7 @@ int basic_test() {
 
   pre_decrypt(decrypted, params, alice_sk, cipher);
 
-  if (gt_cmp(plaintext->msg, decrypted->msg) == CMP_EQ) {
+  if (gt_cmp(plaintext->msg, decrypted->msg) == RLC_EQ) {
     std::cout << "Encrypt decrypt OK!" << std::endl;
   } else {
     std::cout << "Encrypt decrypt failed!" << std::endl;
@@ -79,7 +79,7 @@ int basic_test() {
 
   pre_decrypt_re(decrypted, params, bob_sk, re_cipher);
 
-  if (gt_cmp(plaintext->msg, decrypted->msg) == CMP_EQ) {
+  if (gt_cmp(plaintext->msg, decrypted->msg) == RLC_EQ) {
     std::cout << "Re-encrypt decrypt OK!" << std::endl;
   } else {
     std::cout << "Re-encrypt decrypt failed!" << std::endl;
@@ -118,17 +118,17 @@ void encode_decode_test() {
   pre_rand_plaintext(plaintext);
   size = get_encoded_plaintext_size(plaintext);
   buff = (char *)malloc(size);
-  if (!encode_plaintext(buff, size, plaintext) == STS_OK) {
+  if (!encode_plaintext(buff, size, plaintext) == RLC_OK) {
     std::cout << "Message encode error!" << std::endl;
     exit(1);
   }
-  if (!decode_plaintext(plaintext_decoded, buff, size) == STS_OK) {
+  if (!decode_plaintext(plaintext_decoded, buff, size) == RLC_OK) {
     std::cout << "Message decode error!" << std::endl;
     exit(1);
   }
   free(buff);
 
-  if (gt_cmp(plaintext->msg, plaintext_decoded->msg) == CMP_EQ) {
+  if (gt_cmp(plaintext->msg, plaintext_decoded->msg) == RLC_EQ) {
     std::cout << "Decode message OK!" << std::endl;
   } else {
     std::cout << "Decode message Failed!" << std::endl;
@@ -144,19 +144,19 @@ void encode_decode_test() {
 
   size = get_encoded_params_size(params);
   buff = (char *)malloc(size);
-  if (!encode_params(buff, size, params) == STS_OK) {
+  if (!encode_params(buff, size, params) == RLC_OK) {
     std::cout << "Params encode error!" << std::endl;
     exit(1);
   }
-  if (!decode_params(params_decoded, buff, size) == STS_OK) {
+  if (!decode_params(params_decoded, buff, size) == RLC_OK) {
     std::cout << "Params decode error!" << std::endl;
     exit(1);
   }
   free(buff);
 
-  if (gt_cmp(params->Z, params_decoded->Z) == CMP_EQ &&
-      g1_cmp(params->g1, params_decoded->g1) == CMP_EQ &&
-      g2_cmp(params->g2, params_decoded->g2) == CMP_EQ) {
+  if (gt_cmp(params->Z, params_decoded->Z) == RLC_EQ &&
+      g1_cmp(params->g1, params_decoded->g1) == RLC_EQ &&
+      g2_cmp(params->g2, params_decoded->g2) == RLC_EQ) {
     std::cout << "Decode params OK!" << std::endl;
   } else {
     std::cout << "Decode params failed!" << std::endl;
@@ -164,18 +164,18 @@ void encode_decode_test() {
 
   size = get_encoded_sk_size(alice_sk);
   buff = (char *)malloc(size);
-  if (!encode_sk(buff, size, alice_sk) == STS_OK) {
+  if (!encode_sk(buff, size, alice_sk) == RLC_OK) {
     std::cout << "Secret key encode error!" << std::endl;
     exit(1);
   }
-  if (!decode_sk(alice_sk_decoded, buff, size) == STS_OK) {
+  if (!decode_sk(alice_sk_decoded, buff, size) == RLC_OK) {
     std::cout << "Secret key decode error!" << std::endl;
     exit(1);
   }
   free(buff);
 
-  if (bn_cmp(alice_sk->a, alice_sk_decoded->a) == CMP_EQ &&
-      bn_cmp(alice_sk->a_inv, alice_sk_decoded->a_inv) == CMP_EQ) {
+  if (bn_cmp(alice_sk->a, alice_sk_decoded->a) == RLC_EQ &&
+      bn_cmp(alice_sk->a_inv, alice_sk_decoded->a_inv) == RLC_EQ) {
     std::cout << "Secret key OK!" << std::endl;
   } else {
     std::cout << "Secret key failed!" << std::endl;
@@ -183,25 +183,25 @@ void encode_decode_test() {
 
   size = get_encoded_pk_size(alice_pk);
   buff = (char *)malloc(size);
-  if (!encode_pk(buff, size, alice_pk) == STS_OK) {
+  if (!encode_pk(buff, size, alice_pk) == RLC_OK) {
     std::cout << "Public key encode error!" << std::endl;
     exit(1);
   }
-  if (!decode_pk(alice_pk_decoded, buff, size) == STS_OK) {
+  if (!decode_pk(alice_pk_decoded, buff, size) == RLC_OK) {
     std::cout << "Public key decode error!" << std::endl;
     exit(1);
   }
   free(buff);
 
-  if (g1_cmp(alice_pk->pk1, alice_pk_decoded->pk1) == CMP_EQ &&
-      g2_cmp(alice_pk->pk2, alice_pk_decoded->pk2) == CMP_EQ) {
+  if (g1_cmp(alice_pk->pk1, alice_pk_decoded->pk1) == RLC_EQ &&
+      g2_cmp(alice_pk->pk2, alice_pk_decoded->pk2) == RLC_EQ) {
     std::cout << "Decode public key OK!" << std::endl;
   } else {
     std::cout << "Decode public key failed!" << std::endl;
   }
 
-  if (g1_cmp(alice_pk->pk1, alice_pk_decoded->pk1) == CMP_EQ &&
-      g2_cmp(alice_pk->pk2, alice_pk_decoded->pk2) == CMP_EQ) {
+  if (g1_cmp(alice_pk->pk1, alice_pk_decoded->pk1) == RLC_EQ &&
+      g2_cmp(alice_pk->pk2, alice_pk_decoded->pk2) == RLC_EQ) {
     std::cout << "Public key OK!" << std::endl;
   } else {
     std::cout << "Public key failed!" << std::endl;
@@ -209,17 +209,17 @@ void encode_decode_test() {
 
   size = get_encoded_token_size(token_to_bob);
   buff = (char *)malloc(size);
-  if (!encode_token(buff, size, token_to_bob) == STS_OK) {
+  if (!encode_token(buff, size, token_to_bob) == RLC_OK) {
     std::cout << "Token encode error!" << std::endl;
     exit(1);
   }
-  if (!decode_token(token_to_bob_decode, buff, size) == STS_OK) {
+  if (!decode_token(token_to_bob_decode, buff, size) == RLC_OK) {
     std::cout << "Token decode error!" << std::endl;
     exit(1);
   }
   free(buff);
 
-  if (g2_cmp(token_to_bob->token, token_to_bob_decode->token) == CMP_EQ) {
+  if (g2_cmp(token_to_bob->token, token_to_bob_decode->token) == RLC_EQ) {
     std::cout << "Decode token OK!" << std::endl;
   } else {
     std::cout << "Decode token failed!" << std::endl;
@@ -231,8 +231,8 @@ void encode_decode_test() {
   decode_ciphertext(alice_cipher1_decode, buff, size);
   free(buff);
 
-  if (gt_cmp(alice_cipher1->c1, alice_cipher1_decode->c1) == CMP_EQ &&
-      g1_cmp(alice_cipher1->c2, alice_cipher1_decode->c2) == CMP_EQ) {
+  if (gt_cmp(alice_cipher1->c1, alice_cipher1_decode->c1) == RLC_EQ &&
+      g1_cmp(alice_cipher1->c2, alice_cipher1_decode->c2) == RLC_EQ) {
     std::cout << "Decode cipher OK!" << std::endl;
   } else {
     std::cout << "Decode cipher failed!" << std::endl;
@@ -246,14 +246,14 @@ void encode_decode_test() {
   decode_re_ciphertext(bob_re_decode, buff, size);
   free(buff);
 
-  if (gt_cmp(bob_re->c1, bob_re_decode->c1) == CMP_EQ &&
-      gt_cmp(bob_re->c2, bob_re_decode->c2) == CMP_EQ) {
+  if (gt_cmp(bob_re->c1, bob_re_decode->c1) == RLC_EQ &&
+      gt_cmp(bob_re->c2, bob_re_decode->c2) == RLC_EQ) {
     std::cout << "Decode re-encrypted cipher OK!" << std::endl;
   } else {
     std::cout << "Decode re-encrypted cipher failed!" << std::endl;
   }
   pre_decrypt(decrypted, params, alice_sk, alice_cipher1);
-  if (gt_cmp(decrypted->msg, plaintext->msg) == CMP_EQ) {
+  if (gt_cmp(decrypted->msg, plaintext->msg) == RLC_EQ) {
     std::cout << "Decrypt OK!" << std::endl;
   } else {
     std::cout << "Dec Failed!" << std::endl;

--- a/pre/utils.c
+++ b/pre/utils.c
@@ -38,27 +38,27 @@
 #include <limits.h>
 
 int pre_init() {
-  if (core_init() != STS_OK) {
+  if (core_init() != RLC_OK) {
     core_clean();
-    return STS_ERR;
+    return RLC_ERR;
   }
 
-  if (pc_param_set_any() != STS_OK) {
+  if (pc_param_set_any() != RLC_OK) {
     THROW(ERR_NO_CURVE);
     core_clean();
-    return STS_ERR;
+    return RLC_ERR;
   }
   pc_param_print();
-  return STS_OK;
+  return RLC_OK;
 }
 
 int pre_cleanup() {
   core_clean();
-  return STS_OK;
+  return RLC_OK;
 }
 
 int pre_rand_plaintext(pre_plaintext_t plaintext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     gt_new(plaintext->msg);
@@ -66,14 +66,14 @@ int pre_rand_plaintext(pre_plaintext_t plaintext) {
   }
   CATCH_ANY {
     gt_free(plaintext->msg);
-    result = STS_ERR;
+    result = RLC_ERR;
   }
 
   return result;
 }
 
 int pre_map_to_key(uint8_t *key, int key_len, pre_plaintext_t plaintext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   size_t buff_size;
 
@@ -83,13 +83,13 @@ int pre_map_to_key(uint8_t *key, int key_len, pre_plaintext_t plaintext) {
     gt_write_bin(buffer, (int)buff_size, plaintext->msg, 1);
     md_kdf2(key, key_len, buffer, (int)buff_size);
   }
-  CATCH_ANY { result = STS_ERR; };
+  CATCH_ANY { result = RLC_ERR; };
 
   return result;
 }
 
 int pre_clean_params(pre_params_t params) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     assert(params);
@@ -98,13 +98,13 @@ int pre_clean_params(pre_params_t params) {
     g1_free(params->g1);
     g2_free(params->g2);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
 
   return result;
 }
 
 int pre_clean_sk(pre_sk_t sk) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     assert(sk);
@@ -112,13 +112,13 @@ int pre_clean_sk(pre_sk_t sk) {
     bn_free(sk->sk);
     bn_free(sk->inverse);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
 
   return result;
 }
 
 int pre_clean_pk(pre_pk_t pk) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     assert(pk);
@@ -126,23 +126,23 @@ int pre_clean_pk(pre_pk_t pk) {
     g1_free(pk->pk1);
     g2_free(pk->pk2);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
 
   return result;
 }
 
 int pre_clean_token(pre_token_t token) {
   g2_free(token->token);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int pre_clean_plaintext(pre_plaintext_t plaintext) {
   gt_free(plaintext->msg);
-  return STS_OK;
+  return RLC_OK;
 }
 
 int pre_clean_ciphertext(pre_ciphertext_t ciphertext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     assert(ciphertext);
@@ -150,13 +150,13 @@ int pre_clean_ciphertext(pre_ciphertext_t ciphertext) {
     gt_free(ciphertext->C1);
     g1_free(ciphertext->C2_G1);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
 
   return result;
 }
 
 int pre_clean_re_ciphertext(pre_re_ciphertext_t ciphertext) {
-  int result = STS_OK;
+  int result = RLC_OK;
 
   TRY {
     assert(ciphertext);
@@ -164,7 +164,7 @@ int pre_clean_re_ciphertext(pre_re_ciphertext_t ciphertext) {
     gt_free(ciphertext->C1);
     gt_free(ciphertext->C2_GT);
   }
-  CATCH_ANY { result = STS_ERR; }
+  CATCH_ANY { result = RLC_ERR; }
 
   return result;
 }

--- a/python-wrapper/pre_python.c
+++ b/python-wrapper/pre_python.c
@@ -33,11 +33,11 @@ static PyObject* py_plaintext_to_ints(PyObject* self, PyObject* args)
         return error(err_context, "parse args");
     }
 
-    if (decode_plaintext(plaintext, plaintext_buf.buf, (int)plaintext_buf.len) != STS_OK) {
+    if (decode_plaintext(plaintext, plaintext_buf.buf, (int)plaintext_buf.len) != RLC_OK) {
         return error(err_context, "decode plaintext");
     }
 
-    if (pre_map_to_key(ret, 16, plaintext) != STS_OK) {
+    if (pre_map_to_key(ret, 16, plaintext) != RLC_OK) {
         return error(err_context, "map plaintext to integers");
     }
 
@@ -62,13 +62,13 @@ static PyObject* py_rand_plaintext(PyObject* self)
     pre_plaintext_t plaintext;
     int size;
 
-    if (pre_rand_plaintext(plaintext) != STS_OK) {
+    if (pre_rand_plaintext(plaintext) != RLC_OK) {
         return error(err_context, "generate random plaintext");
     }
 
     size = get_encoded_plaintext_size(plaintext);
     char plaintext_bytes[size];
-    if (encode_plaintext(plaintext_bytes, size, plaintext) != STS_OK) {
+    if (encode_plaintext(plaintext_bytes, size, plaintext) != RLC_OK) {
         return error(err_context, "encode plaintext");
     }
 
@@ -88,20 +88,20 @@ static PyObject* py_apply_token(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_token(token, token_buf.buf, (int)token_buf.len) != STS_OK) {
+    if(decode_token(token, token_buf.buf, (int)token_buf.len) != RLC_OK) {
         return error(err_context, "decode token");
     }
-    if(decode_ciphertext(ciphertext, ciphertext_buf.buf, (int)ciphertext_buf.len) != STS_OK) {
+    if(decode_ciphertext(ciphertext, ciphertext_buf.buf, (int)ciphertext_buf.len) != RLC_OK) {
         return error(err_context, "decode ciphertext");
     }
 
-    if (pre_apply_token(re_ciphertext, token, ciphertext) != STS_OK) {
+    if (pre_apply_token(re_ciphertext, token, ciphertext) != RLC_OK) {
         return error(err_context, "apply re-encryption token");
     }
 
     size = get_encoded_re_ciphertext_size(re_ciphertext);
     char re_ciphertext_bytes[size];
-    if (encode_re_ciphertext(re_ciphertext_bytes, size, re_ciphertext) != STS_OK) {
+    if (encode_re_ciphertext(re_ciphertext_bytes, size, re_ciphertext) != RLC_OK) {
         return error(err_context, "encode re-encrypted ciphertext");
     }
 
@@ -122,23 +122,23 @@ static PyObject* py_generate_token(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_params(params, params_buf.buf, (int)params_buf.len) != STS_OK) {
+    if(decode_params(params, params_buf.buf, (int)params_buf.len) != RLC_OK) {
         return error(err_context, "decode params");
     }
-    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != STS_OK) {
+    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != RLC_OK) {
         return error(err_context, "decode sk");
     }
-    if (decode_pk(pk, pk_buf.buf, (int)pk_buf.len) != STS_OK) {
+    if (decode_pk(pk, pk_buf.buf, (int)pk_buf.len) != RLC_OK) {
         return error(err_context, "decode pk");
     }
 
-    if (pre_generate_token(token, params, sk, pk) != STS_OK) {
+    if (pre_generate_token(token, params, sk, pk) != RLC_OK) {
         return error(err_context, "generate re-encryption token");
     }
 
     size = get_encoded_token_size(token);
     char token_bytes[size];
-    if (encode_token(token_bytes, size, token) != STS_OK) {
+    if (encode_token(token_bytes, size, token) != RLC_OK) {
         return error(err_context, "encode token");
     }
 
@@ -159,23 +159,23 @@ static PyObject* py_decrypt_re(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_params(params, params_buf.buf, (int)params_buf.len) != STS_OK) {
+    if(decode_params(params, params_buf.buf, (int)params_buf.len) != RLC_OK) {
         return error(err_context, "decode params");
     }
-    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != STS_OK) {
+    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != RLC_OK) {
         return error(err_context, "decode sk");
     }
-    if (decode_re_ciphertext(re_ciphertext, re_ciphertext_buf.buf, (int)re_ciphertext_buf.len) != STS_OK) {
+    if (decode_re_ciphertext(re_ciphertext, re_ciphertext_buf.buf, (int)re_ciphertext_buf.len) != RLC_OK) {
         return error(err_context, "decode re-encrypted ciphertext");
     }
 
-    if (pre_decrypt_re(plaintext, params, sk, re_ciphertext) != STS_OK) {
+    if (pre_decrypt_re(plaintext, params, sk, re_ciphertext) != RLC_OK) {
         return error(err_context, "decrypt re-encrypted ciphertext");
     }
 
     size = get_encoded_plaintext_size(plaintext);
     char plaintext_bytes[size];
-    if (encode_plaintext(plaintext_bytes, size, plaintext) != STS_OK) {
+    if (encode_plaintext(plaintext_bytes, size, plaintext) != RLC_OK) {
         return error(err_context, "encode plaintext");
     }
 
@@ -196,23 +196,23 @@ static PyObject* py_decrypt(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_params(params, params_buf.buf, (int)params_buf.len) != STS_OK) {
+    if(decode_params(params, params_buf.buf, (int)params_buf.len) != RLC_OK) {
         return error(err_context, "decode params");
     }
-    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != STS_OK) {
+    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != RLC_OK) {
         return error(err_context, "decode sk");
     }
-    if (decode_ciphertext(ciphertext, ciphertext_buf.buf, (int)ciphertext_buf.len) != STS_OK) {
+    if (decode_ciphertext(ciphertext, ciphertext_buf.buf, (int)ciphertext_buf.len) != RLC_OK) {
         return error(err_context, "decode ciphertext");
     }
 
-    if (pre_decrypt(plaintext, params, sk, ciphertext) != STS_OK) {
+    if (pre_decrypt(plaintext, params, sk, ciphertext) != RLC_OK) {
         return error(err_context, "decrypt ciphertext");
     }
 
     size = get_encoded_plaintext_size(plaintext);
     char plaintext_bytes[size];
-    if (encode_plaintext(plaintext_bytes, size, plaintext) != STS_OK) {
+    if (encode_plaintext(plaintext_bytes, size, plaintext) != RLC_OK) {
         return error(err_context, "encode plaintext");
     }
 
@@ -233,24 +233,24 @@ static PyObject* py_encrypt(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_params(params, params_buf.buf, (int)params_buf.len) != STS_OK) {
+    if(decode_params(params, params_buf.buf, (int)params_buf.len) != RLC_OK) {
         return error(err_context, "decode params");
     }
-    if(decode_pk(pk, pk_buf.buf, (int)pk_buf.len) != STS_OK) {
+    if(decode_pk(pk, pk_buf.buf, (int)pk_buf.len) != RLC_OK) {
         return error(err_context, "decode pk");
     }
-    if (decode_plaintext(plaintext, plaintext_buf.buf, (int)plaintext_buf.len) != STS_OK) {
+    if (decode_plaintext(plaintext, plaintext_buf.buf, (int)plaintext_buf.len) != RLC_OK) {
         return error(err_context, "decode plaintext");
     }
 
-    if (pre_encrypt(ciphertext, params, pk, plaintext) != STS_OK) {
+    if (pre_encrypt(ciphertext, params, pk, plaintext) != RLC_OK) {
         return error(err_context, "encrypt plaintext");
     }
 
     size = get_encoded_ciphertext_size(ciphertext);
     char ciphertext_bytes[size];
 
-    if (encode_ciphertext(ciphertext_bytes, size, ciphertext) != STS_OK) {
+    if (encode_ciphertext(ciphertext_bytes, size, ciphertext) != RLC_OK) {
         return error(err_context, "encode ciphertext");
     }
 
@@ -270,20 +270,20 @@ static PyObject* py_derive_pk(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_params(params, params_buf.buf, (int)params_buf.len) != STS_OK) {
+    if(decode_params(params, params_buf.buf, (int)params_buf.len) != RLC_OK) {
         return error(err_context, "decode params");
     }
-    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != STS_OK) {
+    if(decode_sk(sk, sk_buf.buf, (int)sk_buf.len) != RLC_OK) {
         return error(err_context, "decode sk");
     }
 
-    if (pre_derive_pk(pk, params, sk) != STS_OK) {
+    if (pre_derive_pk(pk, params, sk) != RLC_OK) {
         return error(err_context, "generate pk");
     }
 
     size = get_encoded_pk_size(pk);
     char encoded_pk[size];
-    if (encode_pk(encoded_pk, size, pk) != STS_OK) {
+    if (encode_pk(encoded_pk, size, pk) != RLC_OK) {
         return error(err_context, "encode pk");
     }
 
@@ -302,17 +302,17 @@ static PyObject* py_generate_sk(PyObject* self, PyObject* args)
         return error(err_context, "parse arguments");
     }
 
-    if(decode_params(params, params_buf.buf, (int)params_buf.len) != STS_OK) {
+    if(decode_params(params, params_buf.buf, (int)params_buf.len) != RLC_OK) {
         return error(err_context, "decode params");
     }
 
-    if (pre_generate_sk(sk, params) != STS_OK) {
+    if (pre_generate_sk(sk, params) != RLC_OK) {
         return error(err_context, "generate sk");
     }
 
     size = get_encoded_sk_size(sk);
     char encoded_sk[size];
-    if (encode_sk(encoded_sk, size, sk) != STS_OK) {
+    if (encode_sk(encoded_sk, size, sk) != RLC_OK) {
         return error(err_context, "encode sk");
     }
 
@@ -325,13 +325,13 @@ static PyObject* py_generate_params(PyObject* self)
     pre_params_t params;
     int size;
 
-    if (pre_generate_params(params) != STS_OK) {
+    if (pre_generate_params(params) != RLC_OK) {
         return error(err_context, "generate params");
     }
 
     size = get_encoded_params_size(params);
     char encoded_params[size];
-    if (encode_params(encoded_params, size, params) != STS_OK) {
+    if (encode_params(encoded_params, size, params) != RLC_OK) {
         return error(err_context, "encode params");
     }
 


### PR DESCRIPTION
The new relic renames the `STS_ERR` to `RLC_ERR`, and the name of the curve file used for preset.